### PR TITLE
Avoid delay after package registration by cloning General

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,10 +9,21 @@ branding:
 runs:
   using: 'composite'
   steps:
-  # A workaround to avoid delay after package registration. See also julia-runtest.
+    # Occasionally, there are rather large delays (> a few hours)
+    # between the time a package is registered in General and
+    # propagated to pkg.julialang.org.  We can avoid this by manually
+    # cloning ~/.julia/registries/General/ in Julia 1.5 and later.
+    # See:
+    # * https://github.com/JuliaLang/Pkg.jl/issues/2011
+    # * https://github.com/JuliaRegistries/General/issues/16777
+    # * https://github.com/JuliaPackaging/PkgServer.jl/issues/60
   - run: julia --color=yes -e 'using Pkg; VERSION >= v"1.5-" && !isdir(joinpath(DEPOT_PATH[1], "registries", "General")) && Pkg.Registry.add("General")'
     shell: bash
     env:
+      # We set `JULIA_PKG_SERVER` only for this step to enforce
+      # `Pkg.Registry.add` to use Git.  This way, Pkg.jl can send
+      # the request metadata to pkg.julialang.org when installing
+      # packages via `Pkg.test`.
       JULIA_PKG_SERVER: ""
   - run: julia --color=yes --project -e 'using Pkg; if VERSION >= v"1.1.0-rc1"; Pkg.build(verbose=true); else Pkg.build(); end'
     shell: bash

--- a/action.yml
+++ b/action.yml
@@ -9,10 +9,10 @@ branding:
 runs:
   using: 'composite'
   steps:
-    # A workaround to avoid delay after package registration. See also julia-runtest.
-    - run: julia --color=yes -e 'using Pkg; VERSION >= v"1.5-" && !isdir(joinpath(DEPOT_PATH[1], "registries", "General")) && Pkg.Registry.add("General")'
-      shell: bash
-      env:
-        JULIA_PKG_SERVER: ""
+  # A workaround to avoid delay after package registration. See also julia-runtest.
+  - run: julia --color=yes -e 'using Pkg; VERSION >= v"1.5-" && !isdir(joinpath(DEPOT_PATH[1], "registries", "General")) && Pkg.Registry.add("General")'
+    shell: bash
+    env:
+      JULIA_PKG_SERVER: ""
   - run: julia --color=yes --project -e 'using Pkg; if VERSION >= v"1.1.0-rc1"; Pkg.build(verbose=true); else Pkg.build(); end'
     shell: bash

--- a/action.yml
+++ b/action.yml
@@ -9,5 +9,10 @@ branding:
 runs:
   using: 'composite'
   steps:
+    # A workaround to avoid delay after package registration. See also julia-runtest.
+    - run: julia --color=yes -e 'using Pkg; VERSION >= v"1.5-" && !isdir(joinpath(DEPOT_PATH[1], "registries", "General")) && Pkg.Registry.add("General")'
+      shell: bash
+      env:
+        JULIA_PKG_SERVER: ""
   - run: julia --color=yes --project -e 'using Pkg; if VERSION >= v"1.1.0-rc1"; Pkg.build(verbose=true); else Pkg.build(); end'
     shell: bash


### PR DESCRIPTION
This PR applies the workaround https://github.com/julia-actions/julia-runtest/pull/17 to julia-buildpkg.

See https://github.com/tkf/Baselet.jl/pull/16 for an example.