### PR TITLE
Put the General registry clone inside a bounded retry loop

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,7 @@ runs:
     # * https://github.com/JuliaLang/Pkg.jl/issues/2011
     # * https://github.com/JuliaRegistries/General/issues/16777
     # * https://github.com/JuliaPackaging/PkgServer.jl/issues/60
-  - run: julia --color=yes -e 'using Pkg; VERSION >= v"1.5-" && !isdir(joinpath(DEPOT_PATH[1], "registries", "General")) && Pkg.Registry.add("General")'
+  - run: julia --color=yes "$GITHUB_ACTION_PATH"/add_general_registry.jl
     shell: bash
     env:
       # We set `JULIA_PKG_SERVER` only for this step to enforce
@@ -25,5 +25,6 @@ runs:
       # the request metadata to pkg.julialang.org when installing
       # packages via `Pkg.test`.
       JULIA_PKG_SERVER: ""
+
   - run: julia --color=yes --project -e 'using Pkg; if VERSION >= v"1.1.0-rc1"; Pkg.build(verbose=true); else Pkg.build(); end'
     shell: bash

--- a/add_general_registry.jl
+++ b/add_general_registry.jl
@@ -1,0 +1,47 @@
+using Pkg
+
+function general_registry_location()
+    general_registry_dir = joinpath(DEPOT_PATH[1], "registries", "General")
+    registry_toml_file = joinpath(general_registry_dir, "Registry.toml")
+    return general_registry_dir, registry_toml_file
+end
+
+function general_registry_exists()
+    general_registry_dir, registry_toml_file = general_registry_location()
+    if !isdir(general_registry_dir)
+        return false
+    elseif !isfile(registry_toml_file)
+        return false
+    else
+        return true
+    end
+end
+
+function add_general_registry()
+    @info("Attempting to clone the General registry")
+    general_registry_dir, registry_toml_file = general_registry_location()
+    rm(general_registry_dir; force = true, recursive = true)
+    Pkg.Registry.add("General")
+    isfile(registry_toml_file) || throw(ErrorException("the Registry.toml file does not exist"))
+    return nothing
+end
+
+function main(; n = 10, max_delay = 120)
+    if VERSION >= v"1.5-"
+        if !general_registry_exists()
+            delays = ExponentialBackOff(; n = n, max_delay = max_delay)
+            try
+                retry(add_general_registry; delays = delays)()
+                @info("Successfully added the General registry")
+            catch ex
+                msg = "I was unable to added the General registry. However, the build will continue."
+                @error(msg, exception=(ex,catch_backtrace()))
+            end
+        else
+            @info("The General registry already exists locally")
+        end
+    end
+    return nothing
+end
+
+main()

--- a/add_general_registry.jl
+++ b/add_general_registry.jl
@@ -39,7 +39,7 @@ function main(; n = 10, max_delay = 120)
         retry(add_general_registry; delays = delays)()
         @info("Successfully added the General registry")
     catch ex
-        msg = "I was unable to added the General registry. However, the build will continue."
+        msg = "I was unable to add the General registry. However, the build will continue."
         @error(msg, exception=(ex,catch_backtrace()))
     end
 

--- a/add_general_registry.jl
+++ b/add_general_registry.jl
@@ -27,21 +27,23 @@ function add_general_registry()
 end
 
 function main(; n = 10, max_delay = 120)
-    if VERSION >= v"1.5-"
-        if !general_registry_exists()
-            delays = ExponentialBackOff(; n = n, max_delay = max_delay)
-            try
-                retry(add_general_registry; delays = delays)()
-                @info("Successfully added the General registry")
-            catch ex
-                msg = "I was unable to added the General registry. However, the build will continue."
-                @error(msg, exception=(ex,catch_backtrace()))
-            end
-        else
-            @info("The General registry already exists locally")
-        end
+    VERSION >= v"1.5-" || return
+
+    if general_registry_exists()
+        @info("The General registry already exists locally")
+        return
     end
-    return nothing
+
+    delays = ExponentialBackOff(; n = n, max_delay = max_delay)
+    try
+        retry(add_general_registry; delays = delays)()
+        @info("Successfully added the General registry")
+    catch ex
+        msg = "I was unable to added the General registry. However, the build will continue."
+        @error(msg, exception=(ex,catch_backtrace()))
+    end
+
+    return
 end
 
 main()


### PR DESCRIPTION
Fixes #7 

1. Put the General registry clone inside a bounded retry loop
2. Continue the build even if the General registry clone fails

See also: https://github.com/julia-actions/julia-runtest/pull/31