### PR TITLE
add prefix option, to match julia-runtest

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,10 @@ inputs:
   project:
     description: 'Value passed to the --project flag. The default value is the repository root: "@."'
     default: '@.'
+  prefix:
+    description: 'Value inserted in front of the julia command, e.g. for running xvfb-run julia [...]'
+    default: ''
+    required: false
 
 runs:
   using: 'composite'
@@ -31,5 +35,14 @@ runs:
       # packages via `Pkg.test`.
       JULIA_PKG_SERVER: ""
 
-  - run: julia --color=yes --project=${{ inputs.project }} -e 'using Pkg; if VERSION >= v"1.1.0-rc1"; Pkg.build(verbose=true); else Pkg.build(); end'
+  - run: |
+        # The Julia command that will be executed
+        julia_cmd=( julia --color=yes --project=${{ inputs.project }} -e 'using Pkg; if VERSION >= v"1.1.0-rc1"; Pkg.build(verbose=true); else Pkg.build(); end' )
+
+        # Add the prefix in front of the command if there is one
+        prefix="${{ inputs.prefix }}"
+        [[ -n $prefix ]] && julia_cmd=( "$prefix" "${julia_cmd[@]}" )
+
+        # Run the Julia command
+        "${julia_cmd[@]}"
     shell: bash


### PR DESCRIPTION
If `xvfb-run` etc. is needed to run tests, it likely will be needed at build time too, which is the case for CimGui.jl