### PR TITLE
disable autoprecompile by default

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,9 @@ inputs:
   project:
     description: 'Value passed to the --project flag. The default value is the repository root: "@."'
     default: '@.'
+  precompile:
+    description: 'Whether to allow auto-precompilation (via the `JULIA_PKG_PRECOMPILE_AUTO` env var). Options: yes | no. Default value: no.'
+    default: 'no'
 
 runs:
   using: 'composite'
@@ -33,3 +36,5 @@ runs:
 
   - run: julia --color=yes --project=${{ inputs.project }} -e 'using Pkg; if VERSION >= v"1.1.0-rc1"; Pkg.build(verbose=true); else Pkg.build(); end'
     shell: bash
+    env:
+      JULIA_PKG_PRECOMPILE_AUTO: "${{ inputs.precompile }}"


### PR DESCRIPTION
With native code caching incoming, doing (auto)precompilation at this stage of CI is suboptimal because the native caches will be generated for a julia setup that doesn't match the test julia setup i.e. bounds checking. which would cause precompilation in this step and in a following `julia-runtest` step.

This disables auto-precompilation here, but exposes it as an option to re-enable.

My hope here is that we can release this as a non-breaking change so we can avoid a load more unnecessary precompilation once native caching lands.