### PR TITLE
use Pkg server and eager registry by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,9 @@ jobs:
         pkg-server:
           - ""
           - "pkg.julialang.org"
+        registry-flavor:
+          - "eager"
+          - "conservative"
         # 32-bit Julia binaries are not available on macOS
         exclude:
           - os: macOS-latest
@@ -72,6 +75,7 @@ jobs:
       - uses: ./.github/actions/julia-buildpkg
         env:
           JULIA_PKG_SERVER: ${{ matrix.pkg-server }}
+          JULIA_PKG_SERVER_REGISTRY_PREFERENCE: ${{ matrix.registry-flavor }}
 
       - uses: julia-actions/julia-runtest@v1
 

--- a/add_general_registry.buildpkg.jl
+++ b/add_general_registry.buildpkg.jl
@@ -37,12 +37,8 @@ function add_general_registry()
     general_registry_dir, registry_toml_file = cloned_general_registry_location()
     rm(general_registry_dir; force = true, recursive = true)
 
-    # If not already set, We set `JULIA_PKG_SERVER` to enforce
-    # `Pkg.Registry.add` to use Git.  This way, Pkg.jl can send
-    # the request metadata to pkg.julialang.org when installing
-    # packages via `Pkg.test`.
-    pkg_server = get(ENV, "JULIA_PKG_SERVER", "")
-    withenv("JULIA_PKG_SERVER" => pkg_server) do
+    registry_flavor = get(ENV, "JULIA_PKG_SERVER_REGISTRY_PREFERENCE", "eager")
+    withenv("JULIA_PKG_SERVER_REGISTRY_PREFERENCE" => registry_flavor) do
         Pkg.Registry.add("General")
     end
 


### PR DESCRIPTION
This speeds up julia-buildpkg considerably.
Fixes #14