### PR TITLE
Revert shortcut for missing deps/build.jl file.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,6 @@ runs:
   using: 'composite'
   steps:
   - run: |
-      isfile("deps/build.jl") || exit()
       import Pkg
       VERSION >= v"1.5-" && Pkg.Registry.add("General")
       VERSION >= v"1.1.0-rc1" ? Pkg.build(verbose=true) : Pkg.build()


### PR DESCRIPTION
@SaschaMann I just realized this part of the change might not work nice with caching etc so I suggest revering this part for now.

For example, some packages create files in .julia/scratch or similar during build, that might not be cached.