### PR TITLE
Add localregistry input option

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,29 @@ is already set. If you want another registry flavor (i.e. `conservative`) this
 should be defined in the `env:` section of the relevant workflow or step. See
 [Registry flavors](https://pkgdocs.julialang.org/dev/registries/#Registry-flavors)
 for more information.
+
+### Adding Local Registries
+
+Personal registries, e.g. created with [LocalRegistry.jl](https://github.com/GunnarFarneback/LocalRegistry.jl), can be added to the CI using the `localregistry` input option. If the personal registry as well as packages needed in the current project are public, no additional setup is required if the registry url is specified in https-format.
+
+If the registry contains private packages, or is itself private, the ssh protocol should to be used. The user has to provide the corresponding private SSH-keys to the `ssh-agent` to access packages and registry. This can be conveniently done using the [webfactory/ssh-agent](https://github.com/webfactory/ssh-agent) action. A snippet illustrating the usage of (private) personal registries is shown below
+
+```yaml
+...   
+      # Adding private SSH keys (only necessary for accessing private packages and/or 
+      # when providing Registry-link in ssh format)
+      - uses: webfactory/ssh-agent@v0.8.0
+        with:
+          ssh-private-key: |
+            ${{ secrets.PRIVATE_DEPLOY_KEY }}
+            ${{ secrets.PRIVATE_DEPLOY_KEY2 }}
+      - uses: julia-actions/julia-buildpkg@main # Update @main once new taged version available
+        with:
+          localregistry: |
+            https://github.com/username/PersonalRegistry.git
+            git@github.com:username2/PersonalRegistry2.git
+          git_cli: false # = JULIA_PKG_USE_CLI_GIT. Options: true | false (default)
+...
+```
+
+For Julia 1.7 and above, the `git_cli` option can be used to set the `JULIA_PKG_USE_CLI_GIT` [environment flag](https://docs.julialang.org/en/v1/manual/environment-variables/), for additional control of the SSH configuration used by `Pkg` to add/dev packages.

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ If the registry contains private packages, or is itself private, the ssh protoco
           ssh-private-key: |
             ${{ secrets.PRIVATE_DEPLOY_KEY }}
             ${{ secrets.PRIVATE_DEPLOY_KEY2 }}
-      - uses: julia-actions/julia-buildpkg@main # Update @main once new taged version available
+      - uses: julia-actions/julia-buildpkg@v1
         with:
           localregistry: |
             https://github.com/username/PersonalRegistry.git

--- a/action.yml
+++ b/action.yml
@@ -14,11 +14,13 @@ inputs:
     description: 'Whether to allow auto-precompilation (via the `JULIA_PKG_PRECOMPILE_AUTO` env var). Options: yes | no. Default value: no.'
     default: 'no'
   localregistry:
-    description: 'Add local registries hosted on GitHub. Speciefied by providing the url (https) to the repositories as a single-space seperated list'
+    description: 'Add local registries hosted on GitHub. Speciefied by providing the url (https/ssh) to the repositories as a newline (\n) seperated list.
+                  User is responsible for setting up the necessary SSH-Keys to access the repositories if necessary.'
     default: ''
-  token:
-    description: 'GitHub Token used to acces the localregistries. Default: User GitHub token.'
-    default: ${{ github.token }}
+  git_cli:
+    description: 'Determine if Pkg uses the cli git executable (Julia >= 1.7). Might be necessary for more complicated SSH setups.
+                  Options: true | false. Default : false'
+    default: 'false'
 
 runs:
   using: 'composite'
@@ -28,13 +30,18 @@ runs:
     shell: bash
   - run: |
       import Pkg
+      
+      # Determine if Pkg uses git-cli executable instead of LibGit2
+      VERSION >= v"1.7-" && (ENV["JULIA_PKG_USE_CLI_GIT"] = ${{ inputs.git_cli }})
+
       if VERSION >= v"1.5-"
           Pkg.Registry.add("General")
-        
+
           # If provided add local registries
           if !isempty("${{ inputs.localregistry }}")
-            local_repos = split("${{ inputs.localregistry }}", " ") .|> string        
+            local_repos = split("${{ inputs.localregistry }}", "\n") .|> string   
             for repo_url in local_repos
+              isempty(repo_url) && continue
               Pkg.Registry.add(Pkg.RegistrySpec(; url = repo_url))
             end
           end
@@ -44,5 +51,4 @@ runs:
     shell: julia --color=yes --project=${{ inputs.project }} {0}
     env:
       JULIA_PKG_PRECOMPILE_AUTO: "${{ inputs.precompile }}"
-      GITHUB_TOKEN: ${{ inputs.token }} # For authentication with GitHub Actions token
-      
+      GITHUB_TOKEN: ${{ github.token }}

--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ inputs:
     description: 'Whether to allow auto-precompilation (via the `JULIA_PKG_PRECOMPILE_AUTO` env var). Options: yes | no. Default value: no.'
     default: 'no'
   localregistry:
-    description: 'Add local registries hosted on GitHub. Speciefied by providing the url (https/ssh) to the repositories as a newline (\n) seperated list.
+    description: 'Add local registries hosted on GitHub. Specified by providing the url (https/ssh) to the repositories as a newline (\n) seperated list.
                   User is responsible for setting up the necessary SSH-Keys to access the repositories if necessary.'
     default: ''
   git_cli:

--- a/action.yml
+++ b/action.yml
@@ -28,14 +28,16 @@ runs:
     shell: bash
   - run: |
       import Pkg
-      VERSION >= v"1.5-" && Pkg.Registry.add("General")
-      
-      # If provided add local registries
-      if !isempty("${{ inputs.localregistry }}")
-        local_repos = split("${{ inputs.localregistry }}", " ") .|> string        
-        for url in local_repos
-          Pkg.Registry.add(Pkg.RegistrySpec(; url))
-        end
+      if VERSION >= v"1.5-"
+          Pkg.Registry.add("General")
+        
+          # If provided add local registries
+          if !isempty("${{ inputs.localregistry }}")
+            local_repos = split("${{ inputs.localregistry }}", " ") .|> string        
+            for repo_url in local_repos
+              Pkg.Registry.add(Pkg.RegistrySpec(; url = repo_url))
+            end
+          end
       end
       
       VERSION >= v"1.1.0-rc1" ? retry(Pkg.build)(verbose=true) : retry(Pkg.build)()

--- a/action.yml
+++ b/action.yml
@@ -34,6 +34,11 @@ runs:
       # Determine if Pkg uses git-cli executable instead of LibGit2
       VERSION >= v"1.7-" && (ENV["JULIA_PKG_USE_CLI_GIT"] = ${{ inputs.git_cli }})
 
+      if VERSION < v"1.7-" && ${{ inputs.git_cli }} == true
+        printstyled("JULIA_PKG_USE_CLI_GIT requires Julia >= 1.7. Using default LibGit2 git-interface instead! \n"; color = :yellow)
+      end
+
+
       if VERSION >= v"1.5-"
           Pkg.Registry.add("General")
 

--- a/action.yml
+++ b/action.yml
@@ -35,7 +35,7 @@ runs:
       VERSION >= v"1.7-" && (ENV["JULIA_PKG_USE_CLI_GIT"] = ${{ inputs.git_cli }})
 
       if VERSION < v"1.7-" && ${{ inputs.git_cli }} == true
-        printstyled("JULIA_PKG_USE_CLI_GIT requires Julia >= 1.7. Using default LibGit2 git-interface instead! \n"; color = :yellow)
+        printstyled("::notice::JULIA_PKG_USE_CLI_GIT requires Julia >= 1.7. Using default LibGit2 git-interface instead! \n"; color = :yellow)
       end
 
 

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,12 @@ inputs:
   precompile:
     description: 'Whether to allow auto-precompilation (via the `JULIA_PKG_PRECOMPILE_AUTO` env var). Options: yes | no. Default value: no.'
     default: 'no'
+  localregistry:
+    description: 'Add local registries hosted on GitHub. Speciefied by providing the url (https) to the repositories as a single-space seperated list'
+    default: ''
+  token:
+    description: 'GitHub Token used to acces the localregistries. Default: User GitHub token.'
+    default: ${{ github.token }}
 
 runs:
   using: 'composite'
@@ -23,7 +29,18 @@ runs:
   - run: |
       import Pkg
       VERSION >= v"1.5-" && Pkg.Registry.add("General")
+      
+      # If provided add local registries
+      if !isempty("${{ inputs.localregistry }}")
+        local_repos = split("${{ inputs.localregistry }}", " ") .|> string        
+        for url in local_repos
+          Pkg.Registry.add(Pkg.RegistrySpec(; url))
+        end
+      end
+      
       VERSION >= v"1.1.0-rc1" ? retry(Pkg.build)(verbose=true) : retry(Pkg.build)()
     shell: julia --color=yes --project=${{ inputs.project }} {0}
     env:
       JULIA_PKG_PRECOMPILE_AUTO: "${{ inputs.precompile }}"
+      GITHUB_TOKEN: ${{ inputs.token }} # For authentication with GitHub Actions token
+      


### PR DESCRIPTION
Implements and resolves #37 .
Option to add local registries to build process by specifying their url (https). Authentication to the repos via specified GitHub token (default: User Github Token)

Snippet example for using the new flags, that adds two private Registries `CondMatRegistry.git` and `HolyLabRegistry.git`
```yaml
...
      - uses: lukasgrunwald/julia-buildpkg@localregistry
        with:
          localregistry: >- # Collect URL's into space seperated string
            https://github.com/lukasgrunwald/CondMatRegistry.git
            https://github.com/HolyLab/HolyLabRegistry.git
          token: ${{ secrets.GITHUB_TOKEN }} # Automatically generated token
...
```