### PR TITLE
If the user does not specify the optional `git_cli` input, we should respect any pre-existing value of the `JULIA_PKG_USE_CLI_GIT` environment variable

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -47,7 +47,7 @@ runs:
         # `true` or `false`.
         INPUT_GIT_CLI_b = parse(Bool, INPUT_GIT_CLI_str)
         ENV["JULIA_PKG_USE_CLI_GIT"] = "$(INPUT_GIT_CLI_b)"
-        if VERSION < v"1.7-"
+        if (VERSION < v"1.7-") && INPUT_GIT_CLI_b
           printstyled("::notice::JULIA_PKG_USE_CLI_GIT requires Julia >= 1.7. Using default LibGit2 git-interface instead! \n"; color = :yellow)
         end
       end

--- a/action.yml
+++ b/action.yml
@@ -70,4 +70,4 @@ runs:
     env:
       JULIA_PKG_PRECOMPILE_AUTO: "${{ inputs.precompile }}"
       GITHUB_TOKEN: "${{ github.token }}"
-      INPUT_GIT_CLI: "${{ inputs.git_cli }})"
+      INPUT_GIT_CLI: "${{ inputs.git_cli }}"

--- a/action.yml
+++ b/action.yml
@@ -19,8 +19,11 @@ inputs:
     default: ''
   git_cli:
     description: 'Determine if Pkg uses the cli git executable (Julia >= 1.7). Might be necessary for more complicated SSH setups.
-                  Options: true | false. Default : false'
-    default: 'false'
+                  Options: true | false. If this input is provided, it will override any pre-existing value of the
+                  JULIA_PKG_USE_CLI_GIT environment variable. If this input is not provided, and if the JULIA_PKG_USE_CLI_GIT
+                  environnment is set, then that value will be respected. If this input is not provided, and if the
+                  JULIA_PKG_USE_CLI_GIT environment variable is not set, then the default Julia behavior will be used.'
+    default: ''
 
 runs:
   using: 'composite'
@@ -30,30 +33,41 @@ runs:
     shell: bash
   - run: |
       import Pkg
-      
+
       # Determine if Pkg uses git-cli executable instead of LibGit2
-      VERSION >= v"1.7-" && (ENV["JULIA_PKG_USE_CLI_GIT"] = ${{ inputs.git_cli }})
-
-      if VERSION < v"1.7-" && ${{ inputs.git_cli }} == true
-        printstyled("::notice::JULIA_PKG_USE_CLI_GIT requires Julia >= 1.7. Using default LibGit2 git-interface instead! \n"; color = :yellow)
+      #
+      # If the user does not provide the `git_cli` input, we want to make sure
+      # that we respect any pre-existing value of the `JULIA_PKG_USE_CLI_GIT`
+      # environment variable.
+      INPUT_GIT_CLI_str = strip(ENV["INPUT_GIT_CLI"]))
+      if isempty(INPUT_GIT_CLI_str)
+        # Empty = user did not provide this input = we should do nothing.
+      else
+        # Non-empty = user provided this input = we enforce that it must be either
+        # `true` or `false`.
+        INPUT_GIT_CLI_b = parse(Bool, INPUT_GIT_CLI_str)
+        ENV["JULIA_PKG_USE_CLI_GIT"] = "$(INPUT_GIT_CLI_b)"
+        if VERSION < v"1.7-"
+          printstyled("::notice::JULIA_PKG_USE_CLI_GIT requires Julia >= 1.7. Using default LibGit2 git-interface instead! \n"; color = :yellow)
+        end
       end
-
 
       if VERSION >= v"1.5-"
           Pkg.Registry.add("General")
 
           # If provided add local registries
           if !isempty("${{ inputs.localregistry }}")
-            local_repos = split("${{ inputs.localregistry }}", "\n") .|> string   
+            local_repos = split("${{ inputs.localregistry }}", "\n") .|> string
             for repo_url in local_repos
               isempty(repo_url) && continue
               Pkg.Registry.add(Pkg.RegistrySpec(; url = repo_url))
             end
           end
       end
-      
+
       VERSION >= v"1.1.0-rc1" ? retry(Pkg.build)(verbose=true) : retry(Pkg.build)()
     shell: julia --color=yes --project=${{ inputs.project }} {0}
     env:
       JULIA_PKG_PRECOMPILE_AUTO: "${{ inputs.precompile }}"
-      GITHUB_TOKEN: ${{ github.token }}
+      GITHUB_TOKEN: "${{ github.token }}"
+      INPUT_GIT_CLI: "${{ inputs.git_cli }})"

--- a/action.yml
+++ b/action.yml
@@ -39,7 +39,7 @@ runs:
       # If the user does not provide the `git_cli` input, we want to make sure
       # that we respect any pre-existing value of the `JULIA_PKG_USE_CLI_GIT`
       # environment variable.
-      INPUT_GIT_CLI_str = strip(ENV["INPUT_GIT_CLI"]))
+      INPUT_GIT_CLI_str = strip(ENV["INPUT_GIT_CLI"])
       if isempty(INPUT_GIT_CLI_str)
         # Empty = user did not provide this input = we should do nothing.
       else


### PR DESCRIPTION
https://github.com/julia-actions/julia-buildpkg/pull/38#issuecomment-1811514068