### PR TITLE
add suggestion to use cache if no depot is detected

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,17 +58,6 @@ jobs:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
 
-      - uses: actions/cache@v1
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
-
       - uses: ./.github/actions/julia-buildpkg
         with:
           ignore-no-cache: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,8 @@ jobs:
             ${{ runner.os }}-
 
       - uses: ./.github/actions/julia-buildpkg
+        with:
+          ignore-no-cache: true
         env:
           JULIA_PKG_SERVER: ${{ matrix.pkg-server }}
 

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,9 @@ inputs:
     description: 'Determine if Pkg uses the cli git executable (Julia >= 1.7). Might be necessary for more complicated SSH setups.
                   Options: true | false. Default : false'
     default: 'false'
+  ignore-no-cache:
+    description: 'Whether to ignore if there appears to be no depot caching. Silences an action warning.'
+    default: 'no'
 
 runs:
   using: 'composite'
@@ -29,8 +32,11 @@ runs:
     run: echo "JULIA_PKG_SERVER_REGISTRY_PREFERENCE=${JULIA_PKG_SERVER_REGISTRY_PREFERENCE:-eager}" >> ${GITHUB_ENV}
     shell: bash
   - run: |
+      if "${{ inputs.ignore-no-cache }}" == "no" && !isdir(DEPOT_PATH[1])
+          println("::notice title=[julia-buildpkg] Caching of the `~/.julia` depot was not detected ::Consider using `julia-actions/cache` to speed up runs https://github.com/julia-actions/cache. To ignore, set input `ignore-no-cache: yes` ")
+      end
       import Pkg
-      
+
       # Determine if Pkg uses git-cli executable instead of LibGit2
       VERSION >= v"1.7-" && (ENV["JULIA_PKG_USE_CLI_GIT"] = ${{ inputs.git_cli }})
 
@@ -44,14 +50,14 @@ runs:
 
           # If provided add local registries
           if !isempty("${{ inputs.localregistry }}")
-            local_repos = split("${{ inputs.localregistry }}", "\n") .|> string   
+            local_repos = split("${{ inputs.localregistry }}", "\n") .|> string
             for repo_url in local_repos
               isempty(repo_url) && continue
               Pkg.Registry.add(Pkg.RegistrySpec(; url = repo_url))
             end
           end
       end
-      
+
       VERSION >= v"1.1.0-rc1" ? retry(Pkg.build)(verbose=true) : retry(Pkg.build)()
     shell: julia --color=yes --project=${{ inputs.project }} {0}
     env:

--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ runs:
     shell: bash
   - run: |
       if "${{ inputs.ignore-no-cache }}" == "false" && !isdir(DEPOT_PATH[1])
-          println("::notice title=[julia-buildpkg] Caching of the `~/.julia` depot was not detected ::Consider using `julia-actions/cache` to speed up runs https://github.com/julia-actions/cache. To ignore, set input `ignore-no-cache: true` ")
+          println("::notice title=[julia-buildpkg] Caching of the julia depot was not detected ::Consider using `julia-actions/cache` to speed up runs https://github.com/julia-actions/cache. To ignore, set input `ignore-no-cache: true` ")
       end
       import Pkg
 

--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,7 @@ inputs:
     default: 'false'
   ignore-no-cache:
     description: 'Whether to ignore if there appears to be no depot caching. Silences an action warning.'
-    default: 'no'
+    default: 'false'
 
 runs:
   using: 'composite'
@@ -32,8 +32,8 @@ runs:
     run: echo "JULIA_PKG_SERVER_REGISTRY_PREFERENCE=${JULIA_PKG_SERVER_REGISTRY_PREFERENCE:-eager}" >> ${GITHUB_ENV}
     shell: bash
   - run: |
-      if "${{ inputs.ignore-no-cache }}" == "no" && !isdir(DEPOT_PATH[1])
-          println("::notice title=[julia-buildpkg] Caching of the `~/.julia` depot was not detected ::Consider using `julia-actions/cache` to speed up runs https://github.com/julia-actions/cache. To ignore, set input `ignore-no-cache: yes` ")
+      if "${{ inputs.ignore-no-cache }}" == "false" && !isdir(DEPOT_PATH[1])
+          println("::notice title=[julia-buildpkg] Caching of the `~/.julia` depot was not detected ::Consider using `julia-actions/cache` to speed up runs https://github.com/julia-actions/cache. To ignore, set input `ignore-no-cache: true` ")
       end
       import Pkg
 

--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ inputs:
                   Options: true | false. Default : false'
     default: 'false'
   ignore-no-cache:
-    description: 'Whether to ignore if there appears to be no depot caching. Silences an action warning.'
+    description: 'Whether to ignore if there appears to be no depot caching. Silences an action notice recommending `julia-actions/cache`.'
     default: 'false'
 
 runs:


### PR DESCRIPTION
Closes https://github.com/julia-actions/julia-buildpkg/issues/40

Adds a suggestion to use `julia-actions/cache` if no depot is detected.

<img width="658" alt="Screenshot 2023-11-21 at 2 50 00 PM" src="https://github.com/julia-actions/julia-buildpkg/assets/1694067/3f0014da-f2cf-41aa-be7c-0acec75ca19c">

Can be disabled with `ignore-no-cache: true`

If this is approved, I'll do the same for `julia-runtest` (whichever comes first in a run will show the note then create the depot, so we won't end up with double notifications)