### PR TITLE
Remove link trailing dot

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ runs:
     shell: bash
   - run: |
       if "${{ inputs.ignore-no-cache }}" == "false" && !isdir(DEPOT_PATH[1])
-          println("::notice title=[julia-buildpkg] Caching of the julia depot was not detected ::Consider using `julia-actions/cache` to speed up runs https://github.com/julia-actions/cache. To ignore, set input `ignore-no-cache: true` ")
+          println("::notice title=[julia-buildpkg] Caching of the julia depot was not detected ::Consider using `julia-actions/cache` to speed up runs https://github.com/julia-actions/cache To ignore, set input `ignore-no-cache: true` ")
       end
       import Pkg
 


### PR DESCRIPTION
The trailing dots form an invalid link, clicking on it will only result in a 404,
and you will then need to manually remove the dot at the end of the link.

> `https://github.com/julia-actions/cache.`

https://github.com/JuliaCrypto/SHA.jl/actions/runs/7591156618/job/20678829291?pr=100#step:5:46
![image](https://github.com/julia-actions/julia-buildpkg/assets/5158738/ec64b16f-94d7-4759-ab91-eff565a71af3)
