### PR TITLE
Install the default registries for version > 1.8

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -46,7 +46,12 @@ runs:
 
 
       if VERSION >= v"1.5-"
-          Pkg.Registry.add("General")
+          if VERSION >= v"1.8-"
+              # Install the default registries
+              Pkg.Registry.add()
+          else
+              Pkg.Registry.add("General")
+          end
 
           # If provided add local registries
           if !isempty("${{ inputs.localregistry }}")


### PR DESCRIPTION
Adding just `General` can be limiting while dealing with multiple registries. Julia > 1.8 allows adding the default registries.